### PR TITLE
PLATFORM-1172: Check for and return errors when opening the udp socket.

### DIFF
--- a/src/resty_statsd.lua
+++ b/src/resty_statsd.lua
@@ -132,7 +132,11 @@ return function(options)
   local packet_size = options.packet_size or 508 --  RFC791
 
   local udp = socket.udp()
-  udp:setpeername(host, port)
+  local ok, err = udp:setpeername(host, port)
+
+  if not ok then
+    return nil, err
+  end
 
   return {
     namespace = namespace,
@@ -147,6 +151,5 @@ return function(options)
     meter = meter,
     send = send,
     send_to_socket = send_to_socket
-  }
+  }, nil
 end
-


### PR DESCRIPTION
Allows consumers of the client to check if connecting to statsd failed and to then not attempt to send metrics to a closed socket.

Ref: https://github.com/openresty/lua-nginx-module#udpsocksetpeername